### PR TITLE
Email Capture Modal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@
 .byebug_history
 
 .env
+
+tags
+*.log

--- a/app/assets/javascripts/email-modal.js
+++ b/app/assets/javascripts/email-modal.js
@@ -1,0 +1,17 @@
+$( document ).ready(function() {
+  function userIsLoggedIn() {
+    return document.cookie.indexOf('concert_app') > -1;
+  }
+
+  function hasntConfirmedEmail() {
+    return document.cookie.indexOf('concert_app_email') == -1;
+  }
+
+  function showEmailModal() {
+    $('#js--email-modal').modal();
+  }
+
+	if (userIsLoggedIn && hasntConfirmedEmail) {
+    showEmailModal();
+	}
+});

--- a/app/assets/javascripts/email-modal.js
+++ b/app/assets/javascripts/email-modal.js
@@ -1,6 +1,6 @@
 $( document ).ready(function() {
   function userIsLoggedIn() {
-    return document.cookie.indexOf('concert_app') > -1;
+    return document.location.href.indexOf('confirm-email') > -1;
   }
 
   function hasntConfirmedEmail() {
@@ -11,7 +11,7 @@ $( document ).ready(function() {
     $('#js--email-modal').modal();
   }
 
-	if (userIsLoggedIn && hasntConfirmedEmail) {
+	if (userIsLoggedIn() && hasntConfirmedEmail()) {
     showEmailModal();
 	}
 });

--- a/app/assets/javascripts/email-modal.js
+++ b/app/assets/javascripts/email-modal.js
@@ -3,15 +3,11 @@ $( document ).ready(function() {
     return document.location.href.indexOf('confirm-email') > -1;
   }
 
-  function hasntConfirmedEmail() {
-    return document.cookie.indexOf('concert_app_email') == -1;
-  }
-
   function showEmailModal() {
     $('#js--email-modal').modal();
   }
 
-	if (userIsLoggedIn() && hasntConfirmedEmail()) {
+	if (userIsLoggedIn()) {
     showEmailModal();
 	}
 });

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -4,13 +4,8 @@ class SessionsController < ApplicationController
     persistable_auth = persistable_auth_hash(auth)
     user = User.from_oauth(persistable_auth)
     session[:user_id] = user.id
-    cookies[:concert_app] = {
-      :value => Base64.encode64(user.id.to_s),
-      :expires => 1.year.from_now,
-      :domain => 'localhost'
-    }
 
-    redirect_to user_path(user), notice: "Signed in"
+    redirect_to "#{root_url}#confirm-email"
   end
 
   def delete

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -4,7 +4,11 @@ class SessionsController < ApplicationController
     persistable_auth = persistable_auth_hash(auth)
     user = User.from_oauth(persistable_auth)
     session[:user_id] = user.id
-    
+    cookies[:concert_app] = {
+      :value => Base64.encode64(user.id.to_s),
+      :expires => 1.year.from_now,
+      :domain => 'localhost'
+    }
 
     redirect_to user_path(user), notice: "Signed in"
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -15,7 +15,7 @@ class UsersController < ApplicationController
 
   def update
     current_user.update!(user_params)
-    redirect_to current_user, notice: "Your concerts are on the way!" 
+    redirect_to root_path, notice: "Your concerts are on the way!"
   end
 
   private

--- a/app/views/users/_welcome-message.html.erb
+++ b/app/views/users/_welcome-message.html.erb
@@ -145,3 +145,23 @@
       </div>
    </div>
    <!-- /Revolution Slider -->
+
+   <!-- Email Capture Modal -->
+   <div id="js--email-modal" class="modal fade" role="dialog">
+    <div class="modal-dialog">
+  
+      <div class="modal-content">
+        <div class="modal-header">
+          <button type="button" class="close" data-dismiss="modal">&times;</button>
+          <h4 class="modal-title">Modal Header</h4>
+        </div>
+        <div class="modal-body">
+          <p>Some text in the modal.</p>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+        </div>
+      </div>
+  
+    </div>
+  </div>

--- a/app/views/users/_welcome-message.html.erb
+++ b/app/views/users/_welcome-message.html.erb
@@ -153,10 +153,13 @@
       <div class="modal-content">
         <div class="modal-header">
           <button type="button" class="close" data-dismiss="modal">&times;</button>
-          <h4 class="modal-title">Modal Header</h4>
+          <h4 class="modal-title">Confirm or Update Your Email Address</h4>
         </div>
         <div class="modal-body">
-          <p>Some text in the modal.</p>
+          <%= form_for(current_user) do |f| %>
+            <%= f.text_field :email %>
+            <%= f.submit "Confirm Email", class: "btn" %>
+          <% end %>
         </div>
         <div class="modal-footer">
           <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>


### PR DESCRIPTION
- This pull request brings the app to a single page application
- Upon signing in, the user is brought back to root to confirm or update their email (needs to be styled)
- Upon submitting that they are taken back to root again with flash notice confirmation (this could look better)
- Currently, the user could potentially see the modal multiple times if they aren't keeping their session or logging out and back in again.
- Later, may want to consider checking if the user has already confirmed their email somehow, unless you want to keep the flexibility of updating the email every time they log in as it is today.
